### PR TITLE
[issue-83] - Fixed utils.docstring_from() decorator

### DIFF
--- a/src/redflag/utils.py
+++ b/src/redflag/utils.py
@@ -42,8 +42,8 @@ def docstring_from(source_func):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            func.__doc__ = source_func.__doc__
             return func(*args, **kwargs)
+        wrapper.__doc__ = source_func.__doc__
         return wrapper
 
     return decorator

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -58,6 +58,4 @@ def test_series_continuous_report():
 
 def test_feature_importances_docstring():
     s = pd.DataFrame([c, r]).redflag.feature_importances.__doc__
-
-    # There is more to this than I thought. See issue.
-    # assert s.startswith("Measure feature importances on a task, given X and y.")
+    assert s.strip().startswith("Measure feature importances on a task, given X and y.")


### PR DESCRIPTION
This Pull Request Fixes the issue with utils.docstring_from() decorator by copying the __doc__ string to  the the wrapper object.

This helps in fixing this test
- test_feature_importances_docstring (tests/test_pandas.py)